### PR TITLE
Alt Wrong Login Blocker

### DIFF
--- a/common/src/main/java/me/djtheredstoner/devauth/common/DevAuth.java
+++ b/common/src/main/java/me/djtheredstoner/devauth/common/DevAuth.java
@@ -12,7 +12,7 @@ import java.util.*;
 public class DevAuth {
 
     private static final Set<String> authOptions =
-        new HashSet<>(Arrays.asList("--accessToken", "--uuid", "--username", "--userType", "--userProperties"));
+            new HashSet<>(Arrays.asList("--accessToken", "--uuid", "--username", "--userType", "--userProperties"));
 
     private final Properties.BooleanState enabled;
     private final Logger logger;
@@ -40,7 +40,8 @@ public class DevAuth {
             String arg = args[i];
             if (authOptions.contains(arg)) {
                 i++;
-            } else {
+            }
+            else {
                 newArgs.add(arg);
             }
         }
@@ -59,8 +60,11 @@ public class DevAuth {
 
         IAuthProvider authProvider = account.getType().getAuthProviderFactory().create(this);
 
-        SessionData session = authProvider.login(account);
-
+        SessionData session = authProvider.login(account, false);
+        while (account.getForceUsername() != null && !account.getForceUsername().equals(session.getUsername())) {
+            logger.error("Login Blocked: You logined with the wrong Account. You want to login as " + account.getForceUsername() + " but logined as " + session.getUsername() + "!");
+            session = authProvider.login(account, true);
+        }
         logger.info("Successfully logged in as " + session.getUsername());
         return session;
     }
@@ -74,7 +78,8 @@ public class DevAuth {
                 return config.getAccounts().get(commandLineAccount);
             }
             throw new RuntimeException("Account '" + commandLineAccount + "' not found, valid accounts are: " + getValidAccounts());
-        } else if (defaultAccount != null) {
+        }
+        else if (defaultAccount != null) {
             if (config.getAccounts().containsKey(defaultAccount)) {
                 return config.getAccounts().get(defaultAccount);
             }
@@ -86,7 +91,8 @@ public class DevAuth {
     public boolean isEnabled(boolean defaultEnabled) {
         if (enabled == Properties.BooleanState.NOT_SET) {
             return defaultEnabled;
-        } else {
+        }
+        else {
             return enabled.toBoolean();
         }
     }

--- a/common/src/main/java/me/djtheredstoner/devauth/common/auth/IAuthProvider.java
+++ b/common/src/main/java/me/djtheredstoner/devauth/common/auth/IAuthProvider.java
@@ -4,6 +4,6 @@ import me.djtheredstoner.devauth.common.config.Account;
 
 public interface IAuthProvider {
 
-    SessionData login(Account account);
+    SessionData login(Account account, Boolean reLogin);
 
 }

--- a/common/src/main/java/me/djtheredstoner/devauth/common/auth/MojangAuthProvider.java
+++ b/common/src/main/java/me/djtheredstoner/devauth/common/auth/MojangAuthProvider.java
@@ -11,7 +11,7 @@ import java.net.Proxy;
 public class MojangAuthProvider implements IAuthProvider {
 
     @Override
-    public SessionData login(Account account) {
+    public SessionData login(Account account, Boolean relogin) {
         UserAuthentication auth = new YggdrasilAuthenticationService(Proxy.NO_PROXY, "1")
             .createUserAuthentication(Agent.MINECRAFT);
 

--- a/common/src/main/java/me/djtheredstoner/devauth/common/config/Account.java
+++ b/common/src/main/java/me/djtheredstoner/devauth/common/config/Account.java
@@ -6,12 +6,14 @@ public class Account {
     private final AccountType type;
     private final String username;
     private final String password;
+    private final String forceUsername;
 
-    public Account(String name, AccountType type, String username, String password) {
+    public Account(String name, AccountType type, String username, String password, String forceUsername) {
         this.name = name;
         this.type = type;
         this.username = username;
         this.password = password;
+        this.forceUsername = forceUsername;
     }
 
     public String getName() {
@@ -28,5 +30,9 @@ public class Account {
 
     public String getPassword() {
         return password;
+    }
+
+    public String getForceUsername() {
+        return forceUsername;
     }
 }

--- a/common/src/main/java/me/djtheredstoner/devauth/common/config/DevAuthConfig.java
+++ b/common/src/main/java/me/djtheredstoner/devauth/common/config/DevAuthConfig.java
@@ -66,7 +66,8 @@ public class DevAuthConfig {
                 entry.getKey(),
                 AccountType.of(value.get("type")),
                 value.get("username"),
-                value.get("password")
+                value.get("password"),
+                value.get("forcedusername")
             ));
         }
 

--- a/readme.md
+++ b/readme.md
@@ -107,8 +107,10 @@ defaultAccount = "main"
 type = "microsoft"
 
 # A second account, which can be selected by changing defaultAccount above or using the devauth.account property
+# forcedusername makes it so you can only login with the username specified. This is so If you want to use different Accounts you cant login with the other one by accident
 [accounts.alt]
 type = "microsoft"
+forcedusername = "examplename"
 ```
 When the `devauth.account` property is specified it takes precedence over the
 `defaultAccount` config option.


### PR DESCRIPTION
This PR adds a new account parameter named `forcedusername`. When it is set you get OAuth requests until the OAuth is completed with the set Username. Otherwise, you are prompted with an Error that tells you which Account is wanted and as which you loged in. See the readme for how to set it up.

I want to point out that I did not add support for Mojang Account login since it can not be used anymore anyway to my knowledge.